### PR TITLE
SEO: BrowserRouter移行 + プリレンダリング + メタタグ最適化

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,37 @@
       name="description"
       content="Hiroki Asano is a Tanka Poet / Software Developer."
     />
+    <meta property="og:title" content="ashnoa.com" />
+    <meta property="og:description" content="Hiroki Asano is a Tanka Poet / Software Developer." />
+    <meta property="og:url" content="https://ashnoa.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://ashnoa.com/images/ashnoa.JPG" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="ashnoa.com" />
+    <meta name="twitter:description" content="Hiroki Asano is a Tanka Poet / Software Developer." />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Serif+JP:wght@200&display=swap" rel="stylesheet">
     <title>ashnoa.com</title>
+    <script>
+      // Redirect hash-based URLs to clean URLs (e.g. /#/olel → /olel)
+      (function() {
+        var hash = window.location.hash;
+        if (hash && hash.startsWith('#/')) {
+          window.history.replaceState(null, '', hash.substring(1));
+        }
+      })();
+      // Restore path from GitHub Pages 404 redirect
+      (function() {
+        var redirect = sessionStorage.getItem('gh-pages-redirect');
+        if (redirect) {
+          sessionStorage.removeItem('gh-pages-redirect');
+          window.history.replaceState(null, '', redirect);
+        }
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "motion": "^12.29.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^7.0.2",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
@@ -46,6 +47,7 @@
         "gh-pages": "^6.1.1",
         "globals": "^15.13.0",
         "prettier": "3.4.2",
+        "puppeteer": "^24.40.0",
         "typescript-eslint": "^8.17.0",
         "vite": "^6.4.1"
       }
@@ -2012,12 +2014,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -2031,18 +2027,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
@@ -2181,6 +2165,39 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -2899,6 +2916,12 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3025,6 +3048,16 @@
         "@types/jest": "*"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
@@ -3081,6 +3114,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3132,6 +3174,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -3279,6 +3327,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -3297,6 +3357,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -3343,6 +3417,102 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+      "integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+      "dev": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
+      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
+      "dev": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.10.0.tgz",
+      "integrity": "sha512-DOPZF/DDcDruKDA43cOw6e9Quq5daua7ygcAwJE/pKJsRWhgSSemi7qVNGE5kyDIxIeN1533G/zfbvWX7Wcb9w==",
+      "dev": true,
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+      "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "dev": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3409,6 +3579,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/call-bind": {
@@ -3524,6 +3703,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -3533,6 +3725,20 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clsx": {
@@ -3611,6 +3817,32 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3634,6 +3866,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
@@ -3687,9 +3928,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
@@ -3772,6 +4013,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3787,6 +4042,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1581282",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+      "dev": true
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -3850,6 +4111,21 @@
       "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
       "dev": true
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
@@ -3860,6 +4136,24 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -4097,6 +4391,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
@@ -4263,12 +4578,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4310,18 +4619,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/locate-path": {
@@ -4398,6 +4695,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -4440,10 +4750,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true
     },
     "node_modules/fast-glob": {
@@ -4481,6 +4826,15 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -4732,6 +5086,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4767,6 +5130,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
@@ -4782,6 +5160,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/gh-pages": {
@@ -5005,6 +5397,32 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5086,6 +5504,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5115,6 +5550,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-async-function": {
       "version": "2.0.0",
@@ -5250,6 +5691,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -5537,6 +5987,18 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -5553,6 +6015,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -5865,6 +6333,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -6002,6 +6476,12 @@
         "node": "*"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
+    },
     "node_modules/motion": {
       "version": "12.29.2",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.29.2.tgz",
@@ -6068,6 +6548,15 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
@@ -6256,6 +6745,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6266,6 +6787,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -6309,6 +6848,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6431,6 +6976,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6448,6 +7002,50 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6455,6 +7053,45 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.40.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.40.0.tgz",
+      "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1581282",
+        "puppeteer-core": "24.40.0",
+        "typed-query-selector": "^2.12.1"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.40.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1581282",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/queue-microtask": {
@@ -6498,6 +7135,24 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-is": {
@@ -6667,6 +7322,15 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -6819,6 +7483,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6917,6 +7586,54 @@
         "node": ">=6"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6934,6 +7651,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -7122,6 +7864,50 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7299,6 +8085,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "4.9.5",
@@ -7814,6 +8606,12 @@
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7918,17 +8716,101 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -7940,6 +8822,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "motion": "^12.29.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^7.0.2",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
@@ -29,7 +30,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/prerender.mjs && node scripts/generate-sitemap.mjs",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
@@ -67,6 +68,7 @@
     "gh-pages": "^6.1.1",
     "globals": "^15.13.0",
     "prettier": "3.4.2",
+    "puppeteer": "^24.40.0",
     "typescript-eslint": "^8.17.0",
     "vite": "^6.4.1"
   },

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    // GitHub Pages SPA redirect
+    // Stores the current path and redirects to / where the SPA will restore it
+    var path = window.location.pathname + window.location.search + window.location.hash;
+    sessionStorage.setItem('gh-pages-redirect', path);
+    window.location.replace('/');
+  </script>
+</head>
+<body></body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://ashnoa.com/sitemap.xml

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "../dist");
+
+const SITE_URL = "https://ashnoa.com";
+
+const routes = [
+  { path: "/", priority: "1.0", changefreq: "monthly" },
+  { path: "/apps", priority: "0.8", changefreq: "monthly" },
+  { path: "/about", priority: "0.6", changefreq: "monthly" },
+  // App detail pages
+  { path: "/olel", priority: "0.7", changefreq: "monthly" },
+  { path: "/zosho", priority: "0.7", changefreq: "monthly" },
+  { path: "/ontape", priority: "0.7", changefreq: "monthly" },
+  { path: "/cashcrew", priority: "0.7", changefreq: "monthly" },
+  { path: "/barnal", priority: "0.7", changefreq: "monthly" },
+  // Legal pages
+  ...["olel", "zosho", "ontape", "cashcrew", "barnal"].flatMap((app) => [
+    {
+      path: `/${app}/privacy-policy`,
+      priority: "0.3",
+      changefreq: "yearly",
+    },
+    {
+      path: `/${app}/terms-of-use`,
+      priority: "0.3",
+      changefreq: "yearly",
+    },
+    {
+      path: `/${app}/terms-of-sale`,
+      priority: "0.3",
+      changefreq: "yearly",
+    },
+  ]),
+];
+
+const today = new Date().toISOString().split("T")[0];
+
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${routes
+  .map(
+    (route) => `  <url>
+    <loc>${SITE_URL}${route.path}</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>${route.changefreq}</changefreq>
+    <priority>${route.priority}</priority>
+  </url>`,
+  )
+  .join("\n")}
+</urlset>`;
+
+fs.writeFileSync(path.join(distDir, "sitemap.xml"), sitemap);
+console.log(`Generated sitemap.xml with ${routes.length} URLs`);

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { appIds } from "./routes.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distDir = path.resolve(__dirname, "../dist");
@@ -12,28 +13,16 @@ const routes = [
   { path: "/apps", priority: "0.8", changefreq: "monthly" },
   { path: "/about", priority: "0.6", changefreq: "monthly" },
   // App detail pages
-  { path: "/olel", priority: "0.7", changefreq: "monthly" },
-  { path: "/zosho", priority: "0.7", changefreq: "monthly" },
-  { path: "/ontape", priority: "0.7", changefreq: "monthly" },
-  { path: "/cashcrew", priority: "0.7", changefreq: "monthly" },
-  { path: "/barnal", priority: "0.7", changefreq: "monthly" },
+  ...appIds.map((id) => ({
+    path: `/${id}`,
+    priority: "0.7",
+    changefreq: "monthly",
+  })),
   // Legal pages
-  ...["olel", "zosho", "ontape", "cashcrew", "barnal"].flatMap((app) => [
-    {
-      path: `/${app}/privacy-policy`,
-      priority: "0.3",
-      changefreq: "yearly",
-    },
-    {
-      path: `/${app}/terms-of-use`,
-      priority: "0.3",
-      changefreq: "yearly",
-    },
-    {
-      path: `/${app}/terms-of-sale`,
-      priority: "0.3",
-      changefreq: "yearly",
-    },
+  ...appIds.flatMap((id) => [
+    { path: `/${id}/privacy-policy`, priority: "0.3", changefreq: "yearly" },
+    { path: `/${id}/terms-of-use`, priority: "0.3", changefreq: "yearly" },
+    { path: `/${id}/terms-of-sale`, priority: "0.3", changefreq: "yearly" },
   ]),
 ];
 

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -3,37 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import puppeteer from "puppeteer";
+import { allRoutes } from "./routes.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const distDir = path.resolve(__dirname, "../dist");
-
-const routes = [
-  "/",
-  "/apps",
-  "/about",
-  "/olel",
-  "/olel/privacy-policy",
-  "/olel/terms-of-use",
-  "/olel/terms-of-sale",
-  "/zosho",
-  "/zosho/privacy-policy",
-  "/zosho/terms-of-use",
-  "/zosho/terms-of-sale",
-  "/ontape",
-  "/ontape/privacy-policy",
-  "/ontape/terms-of-use",
-  "/ontape/terms-of-sale",
-  "/cashcrew",
-  "/cashcrew/privacy-policy",
-  "/cashcrew/terms-of-use",
-  "/cashcrew/terms-of-sale",
-  "/barnal",
-  "/barnal/privacy-policy",
-  "/barnal/terms-of-use",
-  "/barnal/terms-of-sale",
-];
-
-const PORT = 4173;
 
 const MIME_TYPES = {
   ".html": "text/html",
@@ -54,7 +27,8 @@ const MIME_TYPES = {
 function startServer() {
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
-      const url = new URL(req.url, `http://localhost:${PORT}`);
+      const port = server.address().port;
+      const url = new URL(req.url, `http://localhost:${port}`);
       let filePath = path.join(distDir, url.pathname);
 
       // Try exact file, then index.html in directory, then fallback to root index.html (SPA)
@@ -80,7 +54,8 @@ function startServer() {
       }
     });
 
-    server.listen(PORT, () => {
+    // Use port 0 to let the OS assign an available port
+    server.listen(0, () => {
       resolve(server);
     });
   });
@@ -89,12 +64,14 @@ function startServer() {
 async function prerender() {
   console.log("Starting local server...");
   const server = await startServer();
+  const port = server.address().port;
+  console.log(`Server listening on port ${port}`);
 
   console.log("Launching browser...");
   const browser = await puppeteer.launch({ headless: true });
 
   try {
-    for (const route of routes) {
+    for (const route of allRoutes) {
       console.log(`Prerendering: ${route}`);
       const page = await browser.newPage();
       // Block external requests (fonts, analytics) to speed up prerendering
@@ -102,7 +79,7 @@ async function prerender() {
       page.on("request", (req) => {
         const url = req.url();
         if (
-          url.startsWith(`http://localhost:${PORT}`) ||
+          url.startsWith(`http://localhost:${port}`) ||
           url.startsWith("data:")
         ) {
           req.continue();
@@ -111,7 +88,7 @@ async function prerender() {
         }
       });
 
-      await page.goto(`http://localhost:${PORT}${route}`, {
+      await page.goto(`http://localhost:${port}${route}`, {
         waitUntil: "networkidle0",
         timeout: 30000,
       });

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,153 @@
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import puppeteer from "puppeteer";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(__dirname, "../dist");
+
+const routes = [
+  "/",
+  "/apps",
+  "/about",
+  "/olel",
+  "/olel/privacy-policy",
+  "/olel/terms-of-use",
+  "/olel/terms-of-sale",
+  "/zosho",
+  "/zosho/privacy-policy",
+  "/zosho/terms-of-use",
+  "/zosho/terms-of-sale",
+  "/ontape",
+  "/ontape/privacy-policy",
+  "/ontape/terms-of-use",
+  "/ontape/terms-of-sale",
+  "/cashcrew",
+  "/cashcrew/privacy-policy",
+  "/cashcrew/terms-of-use",
+  "/cashcrew/terms-of-sale",
+  "/barnal",
+  "/barnal/privacy-policy",
+  "/barnal/terms-of-use",
+  "/barnal/terms-of-sale",
+];
+
+const PORT = 4173;
+
+const MIME_TYPES = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".txt": "text/plain",
+  ".xml": "text/xml",
+};
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url, `http://localhost:${PORT}`);
+      let filePath = path.join(distDir, url.pathname);
+
+      // Try exact file, then index.html in directory, then fallback to root index.html (SPA)
+      if (!fs.existsSync(filePath) || fs.statSync(filePath).isDirectory()) {
+        const indexPath = path.join(filePath, "index.html");
+        if (fs.existsSync(indexPath)) {
+          filePath = indexPath;
+        } else {
+          filePath = path.join(distDir, "index.html");
+        }
+      }
+
+      const ext = path.extname(filePath);
+      const contentType = MIME_TYPES[ext] || "application/octet-stream";
+
+      try {
+        const content = fs.readFileSync(filePath);
+        res.writeHead(200, { "Content-Type": contentType });
+        res.end(content);
+      } catch {
+        res.writeHead(404);
+        res.end("Not Found");
+      }
+    });
+
+    server.listen(PORT, () => {
+      resolve(server);
+    });
+  });
+}
+
+async function prerender() {
+  console.log("Starting local server...");
+  const server = await startServer();
+
+  console.log("Launching browser...");
+  const browser = await puppeteer.launch({ headless: true });
+
+  try {
+    for (const route of routes) {
+      console.log(`Prerendering: ${route}`);
+      const page = await browser.newPage();
+      // Block external requests (fonts, analytics) to speed up prerendering
+      await page.setRequestInterception(true);
+      page.on("request", (req) => {
+        const url = req.url();
+        if (
+          url.startsWith(`http://localhost:${PORT}`) ||
+          url.startsWith("data:")
+        ) {
+          req.continue();
+        } else {
+          req.abort();
+        }
+      });
+
+      await page.goto(`http://localhost:${PORT}${route}`, {
+        waitUntil: "networkidle0",
+        timeout: 30000,
+      });
+
+      let html = await page.content();
+      // page.content() already includes <!DOCTYPE html>, avoid duplication
+      html = html.replace(/^<!DOCTYPE html>\s*/i, "");
+
+      // Determine output path
+      const outputPath =
+        route === "/"
+          ? path.join(distDir, "index.html")
+          : path.join(distDir, route, "index.html");
+
+      // Ensure directory exists
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, `<!DOCTYPE html>\n${html}`);
+
+      await page.close();
+    }
+
+    // Copy index.html as 404.html fallback
+    const indexHtml = fs.readFileSync(
+      path.join(distDir, "index.html"),
+      "utf-8",
+    );
+    fs.writeFileSync(path.join(distDir, "404.html"), indexHtml);
+
+    console.log("Prerendering complete!");
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+prerender().catch((err) => {
+  console.error("Prerendering failed:", err);
+  process.exit(1);
+});

--- a/scripts/routes.mjs
+++ b/scripts/routes.mjs
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Extract app IDs from src/data/apps.ts
+const appsFile = fs.readFileSync(
+  path.resolve(__dirname, "../src/data/apps.ts"),
+  "utf-8",
+);
+export const appIds = [...appsFile.matchAll(/id:\s*"([^"]+)"/g)].map(
+  (m) => m[1],
+);
+
+const staticRoutes = ["/", "/apps", "/about"];
+
+const appRoutes = appIds.flatMap((id) => [
+  `/${id}`,
+  `/${id}/privacy-policy`,
+  `/${id}/terms-of-use`,
+  `/${id}/terms-of-sale`,
+]);
+
+export const allRoutes = [...staticRoutes, ...appRoutes];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { HashRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
 import { ThemeProvider } from "./context/ThemeContext";
 import { Header } from "./components/Header";
 import { ScrollToTop } from "./components/ScrollToTop";
@@ -25,8 +26,9 @@ import BarnalTermsOfSale from "./BarnalTermsOfSale";
 
 function App() {
   return (
-    <ThemeProvider>
-      <Router>
+    <HelmetProvider>
+      <ThemeProvider>
+        <Router>
         <ScrollToTop />
         <div className="min-h-screen bg-background text-foreground">
           <Header />
@@ -82,8 +84,9 @@ function App() {
             <Route path="*" element={<NotFound />} />
           </Routes>
         </div>
-      </Router>
-    </ThemeProvider>
+        </Router>
+      </ThemeProvider>
+    </HelmetProvider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,61 +29,70 @@ function App() {
     <HelmetProvider>
       <ThemeProvider>
         <Router>
-        <ScrollToTop />
-        <div className="min-h-screen bg-background text-foreground">
-          <Header />
-          <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/apps" element={<Apps />} />
-            <Route path="/about" element={<About />} />
-            {/* Legal pages (must be before dynamic :appId route) */}
-            <Route
-              path="/olel/privacy-policy"
-              element={<OlelPrivacyPolicy />}
-            />
-            <Route path="/olel/terms-of-use" element={<OlelTermsOfUse />} />
-            <Route path="/olel/terms-of-sale" element={<OlelTermsOfSale />} />
-            <Route
-              path="/zosho/privacy-policy"
-              element={<ZoshoPrivacyPolicy />}
-            />
-            <Route path="/zosho/terms-of-use" element={<ZoshoTermsOfUse />} />
-            <Route path="/zosho/terms-of-sale" element={<ZoshoTermsOfSale />} />
-            <Route
-              path="/ontape/privacy-policy"
-              element={<OnTapePrivacyPolicy />}
-            />
-            <Route path="/ontape/terms-of-use" element={<OnTapeTermsOfUse />} />
-            <Route
-              path="/ontape/terms-of-sale"
-              element={<OnTapeTermsOfSale />}
-            />
-            <Route
-              path="/cashcrew/privacy-policy"
-              element={<CashCrewPrivacyPolicy />}
-            />
-            <Route
-              path="/cashcrew/terms-of-use"
-              element={<CashCrewTermsOfUse />}
-            />
-            <Route
-              path="/cashcrew/terms-of-sale"
-              element={<CashCrewTermsOfSale />}
-            />
-            <Route
-              path="/barnal/privacy-policy"
-              element={<BarnalPrivacyPolicy />}
-            />
-            <Route path="/barnal/terms-of-use" element={<BarnalTermsOfUse />} />
-            <Route
-              path="/barnal/terms-of-sale"
-              element={<BarnalTermsOfSale />}
-            />
-            {/* Dynamic app detail page */}
-            <Route path="/:appId" element={<AppDetailPage />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </div>
+          <ScrollToTop />
+          <div className="min-h-screen bg-background text-foreground">
+            <Header />
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/apps" element={<Apps />} />
+              <Route path="/about" element={<About />} />
+              {/* Legal pages (must be before dynamic :appId route) */}
+              <Route
+                path="/olel/privacy-policy"
+                element={<OlelPrivacyPolicy />}
+              />
+              <Route path="/olel/terms-of-use" element={<OlelTermsOfUse />} />
+              <Route path="/olel/terms-of-sale" element={<OlelTermsOfSale />} />
+              <Route
+                path="/zosho/privacy-policy"
+                element={<ZoshoPrivacyPolicy />}
+              />
+              <Route path="/zosho/terms-of-use" element={<ZoshoTermsOfUse />} />
+              <Route
+                path="/zosho/terms-of-sale"
+                element={<ZoshoTermsOfSale />}
+              />
+              <Route
+                path="/ontape/privacy-policy"
+                element={<OnTapePrivacyPolicy />}
+              />
+              <Route
+                path="/ontape/terms-of-use"
+                element={<OnTapeTermsOfUse />}
+              />
+              <Route
+                path="/ontape/terms-of-sale"
+                element={<OnTapeTermsOfSale />}
+              />
+              <Route
+                path="/cashcrew/privacy-policy"
+                element={<CashCrewPrivacyPolicy />}
+              />
+              <Route
+                path="/cashcrew/terms-of-use"
+                element={<CashCrewTermsOfUse />}
+              />
+              <Route
+                path="/cashcrew/terms-of-sale"
+                element={<CashCrewTermsOfSale />}
+              />
+              <Route
+                path="/barnal/privacy-policy"
+                element={<BarnalPrivacyPolicy />}
+              />
+              <Route
+                path="/barnal/terms-of-use"
+                element={<BarnalTermsOfUse />}
+              />
+              <Route
+                path="/barnal/terms-of-sale"
+                element={<BarnalTermsOfSale />}
+              />
+              {/* Dynamic app detail page */}
+              <Route path="/:appId" element={<AppDetailPage />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </div>
         </Router>
       </ThemeProvider>
     </HelmetProvider>

--- a/src/BarnalPrivacyPolicy.tsx
+++ b/src/BarnalPrivacyPolicy.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function BarnalPrivacyPolicy() {
   return (
     <LegalPageLayout appName="Barnal" backPath="/barnal">
+      <SEOHead
+        title="Privacy Policy - Barnal"
+        description="Privacy Policy for Barnal."
+        path="/barnal/privacy-policy"
+      />
       <h1 id="プライバシーポリシー">プライバシーポリシー</h1>
       <p>
         Hiroki Asano（以下「当方」といいます。）は、当方が提供する「Barnal –

--- a/src/BarnalTermsOfSale.tsx
+++ b/src/BarnalTermsOfSale.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function BarnalTermsOfSale() {
   return (
     <LegalPageLayout appName="Barnal" backPath="/barnal">
+      <SEOHead
+        title="Terms of Sale - Barnal"
+        description="Terms of Sale for Barnal."
+        path="/barnal/terms-of-sale"
+      />
       <h1 id="特定商取引法に基づく表示">特定商取引法に基づく表示</h1>
       <h2 id="名称">名称</h2>
       <p>浅野 大輝（Hiroki Asano）</p>

--- a/src/BarnalTermsOfUse.tsx
+++ b/src/BarnalTermsOfUse.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function BarnalTermsOfUse() {
   return (
     <LegalPageLayout appName="Barnal" backPath="/barnal">
+      <SEOHead
+        title="Terms of Use - Barnal"
+        description="Terms of Use for Barnal."
+        path="/barnal/terms-of-use"
+      />
       <h1 id="利用規約">利用規約</h1>
       <p>
         本利用規約（以下「本規約」と言います。）には、本サービスの提供条件及び本サービス開発者であるHiroki

--- a/src/CashCrewPrivacyPolicy.tsx
+++ b/src/CashCrewPrivacyPolicy.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function CashCrewPrivacyPolicy() {
   return (
     <LegalPageLayout appName="CashCrew" backPath="/cashcrew">
+      <SEOHead
+        title="Privacy Policy - CashCrew"
+        description="Privacy Policy for CashCrew."
+        path="/cashcrew/privacy-policy"
+      />
       <h1 id="プライバシーポリシー">プライバシーポリシー</h1>
       <p>
         Hiroki Asano（以下「当方」といいます。）は、当方が提供する「CashCrew -

--- a/src/CashCrewTermsOfSale.tsx
+++ b/src/CashCrewTermsOfSale.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function CashCrewTermsOfSale() {
   return (
     <LegalPageLayout appName="CashCrew" backPath="/cashcrew">
+      <SEOHead
+        title="Terms of Sale - CashCrew"
+        description="Terms of Sale for CashCrew."
+        path="/cashcrew/terms-of-sale"
+      />
       <h1 id="特定商取引法に基づく表示">特定商取引法に基づく表示</h1>
       <h2 id="名称">名称</h2>
       <p>浅野 大輝（Hiroki Asano）</p>

--- a/src/CashCrewTermsOfUse.tsx
+++ b/src/CashCrewTermsOfUse.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function CashCrewTermsOfUse() {
   return (
     <LegalPageLayout appName="CashCrew" backPath="/cashcrew">
+      <SEOHead
+        title="Terms of Use - CashCrew"
+        description="Terms of Use for CashCrew."
+        path="/cashcrew/terms-of-use"
+      />
       <h1 id="利用規約">利用規約</h1>
       <p>
         本利用規約（以下「本規約」と言います。）には、本サービスの提供条件及び本サービス開発者であるHiroki

--- a/src/OlelPrivacyPolicy.tsx
+++ b/src/OlelPrivacyPolicy.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OlelPrivacyPolicy() {
   return (
     <LegalPageLayout appName="olel" backPath="/olel">
+      <SEOHead
+        title="Privacy Policy - olel"
+        description="Privacy Policy for olel."
+        path="/olel/privacy-policy"
+      />
       <h1 id="プライバシーポリシー">プライバシーポリシー</h1>
       <p>
         Hiroki Asano（以下「当方」といいます。）は、当方が提供する「olel -

--- a/src/OlelTermsOfSale.tsx
+++ b/src/OlelTermsOfSale.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OlelTermsOfSale() {
   return (
     <LegalPageLayout appName="olel" backPath="/olel">
+      <SEOHead
+        title="Terms of Sale - olel"
+        description="Terms of Sale for olel."
+        path="/olel/terms-of-sale"
+      />
       <h1 id="特定商取引法に基づく表示">特定商取引法に基づく表示</h1>
       <h2 id="名称">名称</h2>
       <p>浅野 大輝（Hiroki Asano）</p>

--- a/src/OlelTermsOfUse.tsx
+++ b/src/OlelTermsOfUse.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OlelTermsOfUse() {
   return (
     <LegalPageLayout appName="olel" backPath="/olel">
+      <SEOHead
+        title="Terms of Use - olel"
+        description="Terms of Use for olel."
+        path="/olel/terms-of-use"
+      />
       <h1 id="利用規約">利用規約</h1>
       <p>
         本利用規約（以下「本規約」と言います。）には、本サービスの提供条件及び本サービス開発者であるHiroki

--- a/src/OnTapePrivacyPolicy.tsx
+++ b/src/OnTapePrivacyPolicy.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OnTapePrivacyPolicy() {
   return (
     <LegalPageLayout appName="OnTape" backPath="/ontape">
+      <SEOHead
+        title="Privacy Policy - OnTape"
+        description="Privacy Policy for OnTape."
+        path="/ontape/privacy-policy"
+      />
       <h1 id="プライバシーポリシー">プライバシーポリシー</h1>
       <p>
         Hiroki Asano（以下「当方」といいます。）は、当方が提供する「OnTape -

--- a/src/OnTapeTermsOfSale.tsx
+++ b/src/OnTapeTermsOfSale.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OnTapeTermsOfSale() {
   return (
     <LegalPageLayout appName="OnTape" backPath="/ontape">
+      <SEOHead
+        title="Terms of Sale - OnTape"
+        description="Terms of Sale for OnTape."
+        path="/ontape/terms-of-sale"
+      />
       <h1 id="特定商取引法に基づく表示">特定商取引法に基づく表示</h1>
       <h2 id="名称">名称</h2>
       <p>浅野 大輝（Hiroki Asano）</p>

--- a/src/OnTapeTermsOfUse.tsx
+++ b/src/OnTapeTermsOfUse.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function OnTapeTermsOfUse() {
   return (
     <LegalPageLayout appName="OnTape" backPath="/ontape">
+      <SEOHead
+        title="Terms of Use - OnTape"
+        description="Terms of Use for OnTape."
+        path="/ontape/terms-of-use"
+      />
       <h1 id="利用規約">利用規約</h1>
       <p>
         本利用規約（以下「本規約」と言います。）には、本サービスの提供条件及び本サービス開発者であるHiroki

--- a/src/ZoshoPrivacyPolicy.tsx
+++ b/src/ZoshoPrivacyPolicy.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function ZoshoPrivacyPolicy() {
   return (
     <LegalPageLayout appName="Zosho" backPath="/zosho">
+      <SEOHead
+        title="Privacy Policy - Zosho"
+        description="Privacy Policy for Zosho."
+        path="/zosho/privacy-policy"
+      />
       <h1 id="プライバシーポリシー">プライバシーポリシー</h1>
       <p>
         Hiroki Asano（以下「当方」といいます。）は、当方が提供する「Zosho -

--- a/src/ZoshoTermsOfSale.tsx
+++ b/src/ZoshoTermsOfSale.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function ZoshoTermsOfSale() {
   return (
     <LegalPageLayout appName="Zosho" backPath="/zosho">
+      <SEOHead
+        title="Terms of Sale - Zosho"
+        description="Terms of Sale for Zosho."
+        path="/zosho/terms-of-sale"
+      />
       <h1 id="特定商取引法に基づく表示">特定商取引法に基づく表示</h1>
       <h2 id="名称">名称</h2>
       <p>浅野 大輝（Hiroki Asano）</p>

--- a/src/ZoshoTermsOfUse.tsx
+++ b/src/ZoshoTermsOfUse.tsx
@@ -1,8 +1,14 @@
 import { LegalPageLayout } from "./components/LegalPageLayout";
+import { SEOHead } from "./components/SEOHead";
 
 function ZoshoTermsOfUse() {
   return (
     <LegalPageLayout appName="Zosho" backPath="/zosho">
+      <SEOHead
+        title="Terms of Use - Zosho"
+        description="Terms of Use for Zosho."
+        path="/zosho/terms-of-use"
+      />
       <h1 id="利用規約">利用規約</h1>
       <p>
         本利用規約（以下「本規約」と言います。）には、本サービスの提供条件及び本サービス開発者であるHiroki

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -1,0 +1,48 @@
+import { Helmet } from "react-helmet-async";
+
+interface SEOHeadProps {
+  title: string;
+  description: string;
+  path: string;
+  ogImage?: string;
+  jsonLd?: Record<string, unknown>;
+}
+
+const SITE_URL = "https://ashnoa.com";
+
+export function SEOHead({
+  title,
+  description,
+  path,
+  ogImage,
+  jsonLd,
+}: SEOHeadProps) {
+  const fullUrl = `${SITE_URL}${path}`;
+  const fullTitle = title === "ashnoa.com" ? title : `${title} | ashnoa.com`;
+
+  return (
+    <Helmet>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={fullUrl} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={fullUrl} />
+      <meta property="og:type" content="website" />
+      {ogImage && (
+        <meta
+          property="og:image"
+          content={
+            ogImage.startsWith("http") ? ogImage : `${SITE_URL}${ogImage}`
+          }
+        />
+      )}
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+      {jsonLd && (
+        <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      )}
+    </Helmet>
+  );
+}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import { motion } from "motion/react";
 import { Twitter, Mail, MapPin, Youtube, BookOpen } from "lucide-react";
 import { Container } from "../components/Container";
+import { SEOHead } from "../components/SEOHead";
 
 function About() {
   const skills = [
@@ -29,6 +30,12 @@ function About() {
 
   return (
     <div className="min-h-screen pt-32 pb-20">
+      <SEOHead
+        title="About"
+        description="Hiroki Asano, a Tanka poet and software developer based in Japan. Creating simple, intuitive apps with care."
+        path="/about"
+        ogImage="/images/ashnoa.JPG"
+      />
       <Container>
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/src/pages/AppDetailPage.tsx
+++ b/src/pages/AppDetailPage.tsx
@@ -2,6 +2,7 @@ import { useParams, Link, Navigate } from "react-router-dom";
 import { motion } from "motion/react";
 import { ArrowLeft, CheckCircle } from "lucide-react";
 import { Container } from "../components/Container";
+import { SEOHead } from "../components/SEOHead";
 import { apps } from "../data/apps";
 import { useTheme } from "../context/ThemeContext";
 
@@ -16,8 +17,29 @@ function AppDetailPage() {
 
   const isImageIcon = app.icon.startsWith("/");
 
+  const operatingSystem = app.tags.includes("macOS") ? "macOS" : "iOS";
+
   return (
     <div className="min-h-screen pt-32 pb-20">
+      <SEOHead
+        title={`${app.name} - ${app.tagline}`}
+        description={app.description}
+        path={`/${app.id}`}
+        ogImage={app.icon}
+        jsonLd={{
+          "@context": "https://schema.org",
+          "@type": "SoftwareApplication",
+          name: app.name,
+          description: app.description,
+          operatingSystem,
+          applicationCategory: app.tags.filter((t) => t !== "iOS" && t !== "macOS").join(", "),
+          author: {
+            "@type": "Person",
+            name: "Hiroki Asano",
+            url: "https://ashnoa.com",
+          },
+        }}
+      />
       <Container>
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Apps.tsx
+++ b/src/pages/Apps.tsx
@@ -2,10 +2,16 @@ import { motion } from 'motion/react';
 import { Container } from '../components/Container';
 import { AppCard } from '../components/AppCard';
 import { apps } from '../data/apps';
+import { SEOHead } from '../components/SEOHead';
 
 function Apps() {
   return (
     <div className="min-h-screen pt-32 pb-20">
+      <SEOHead
+        title="Apps"
+        description="A collection of carefully crafted applications designed to enhance your workflow and spark creativity."
+        path="/apps"
+      />
       <Container>
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { motion } from 'motion/react';
 import { Twitter, BookOpen, Youtube, ArrowRight, Mail } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Container } from '../components/Container';
+import { SEOHead } from '../components/SEOHead';
 
 function Home() {
   const links = [
@@ -12,6 +13,24 @@ function Home() {
 
   return (
     <div className="min-h-screen pt-32 pb-20">
+      <SEOHead
+        title="Hiroki Asano - Tanka Poet / Software Developer"
+        description="Hiroki Asano is a Tanka Poet / Software Developer based in Japan."
+        path="/"
+        ogImage="/images/ashnoa.JPG"
+        jsonLd={{
+          "@context": "https://schema.org",
+          "@type": "Person",
+          name: "Hiroki Asano",
+          jobTitle: "Software Developer",
+          url: "https://ashnoa.com",
+          sameAs: [
+            "https://twitter.com/ashnoa",
+            "https://youtube.com/@ashnoa",
+            "https://ashnoa.hatenablog.com/",
+          ],
+        }}
+      />
       <Container>
         <motion.div
           initial={{ opacity: 0, y: 20 }}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -2,10 +2,16 @@ import { motion } from 'motion/react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { Container } from '../components/Container';
+import { SEOHead } from '../components/SEOHead';
 
 function NotFound() {
   return (
     <div className="min-h-screen pt-32 pb-20 flex items-center">
+      <SEOHead
+        title="Page Not Found"
+        description="The page you're looking for doesn't exist."
+        path="/404"
+      />
       <Container>
         <motion.div
           initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
## Summary

- HashRouter → BrowserRouter に移行し、クローラーが各ページを個別URLとして認識できるように
- 既存の `/#/` 形式のリンクはリダイレクトスクリプトで保護（既存リンクが壊れない）
- Puppeteer によるビルド時プリレンダリングで全23ルートの静的HTMLを生成
- react-helmet-async で各ページに固有の title, description, OGP メタタグを設定
- JSON-LD 構造化データ（SoftwareApplication / Person）を追加
- sitemap.xml 自動生成、robots.txt にサイトマップURL追加
- GitHub Pages 用 404.html によるSPAフォールバック

## Test plan

- [x] `npm run build` が正常に完了し、全23ページの静的HTMLが生成される
- [x] `/#/olel` 等のハッシュURLが `/olel` にリダイレクトされる
- [x] 各ページの `<title>`, OGP メタタグ, JSON-LD が正しく設定される
- [x] `dist/sitemap.xml` が全URLを含む
- [ ] デプロイ後、Google Search Console でインデックス状況を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)